### PR TITLE
feat: improve canvas controls and min-scale behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@builder.io/qwik": "0.21.0",
         "@builder.io/qwik-city": "0.5.3",
+        "@playwright/test": "^1.60.0",
         "@types/eslint": "8.21.0",
         "@types/lodash.clonedeep": "^4.5.7",
         "@types/node": "^18.14.2",
@@ -2554,6 +2555,22 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/dev": {
@@ -9974,6 +9991,38 @@
         "pathe": "^1.1.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -14340,6 +14389,15 @@
       "dev": true,
       "requires": {
         "json-parse-even-better-errors": "^2.3.1"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
       }
     },
     "@remix-run/dev": {
@@ -19536,6 +19594,22 @@
         "mlly": "^1.1.1",
         "pathe": "^1.1.0"
       }
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.21",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@builder.io/qwik": "0.21.0",
     "@builder.io/qwik-city": "0.5.3",
+    "@playwright/test": "^1.60.0",
     "@types/eslint": "8.21.0",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/node": "^18.14.2",

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -1,5 +1,5 @@
-import { $, component$, useOnDocument, useStore, useTask$ } from '@builder.io/qwik'
-import type { QRL, QwikMouseEvent } from '@builder.io/qwik'
+import { $, component$, useOnDocument, useSignal, useStore, useTask$, useVisibleTask$ } from '@builder.io/qwik'
+import type { QRL } from '@builder.io/qwik'
 
 const Colors = [
   'rgb(255,0,0)',
@@ -22,6 +22,9 @@ interface Props {
 }
 
 export default component$<Props>(({ selectedColor, setSelectedColor }) => {
+  const palateRef = useSignal<HTMLDivElement>()
+  const colorBarRef = useSignal<HTMLDivElement>()
+
   const state = useStore({
     showColorPicker: false,
     baseColor: [0, 0, 0],
@@ -38,7 +41,7 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
   })
 
   const calcBarColor = $((percentX: number) => {
-    percentX = Math.max(Math.min(99.99, percentX), 0) // 0 - 99.99
+    percentX = Math.max(Math.min(99.99, percentX), 0)
     const segmentSize = 100 / 3
 
     const segmentFactor = Math.round(((percentX % segmentSize) / segmentSize) * 2 * 255)
@@ -51,33 +54,6 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
     state.baseColor = rgb
   })
 
-  // Palate mouse move handler
-  const handlePalateMouseEvent = $((e: QwikMouseEvent<HTMLDivElement, MouseEvent>, skipMouseDown?: boolean) => {
-    if (!state.mouseDownPalate && !skipMouseDown) return
-
-    const { offsetX, offsetY } = e.nativeEvent
-    const percentX = (offsetX / Palate.width) * 100
-    const percentY = (offsetY / Palate.height) * 100
-
-    calcPalateColor(percentX, percentY)
-    state.palatePercentX = percentX
-    state.palatePercentY = percentY
-  })
-
-  // Bar mouse move handler
-  const handleColorBarEvent = $((e: QwikMouseEvent<HTMLDivElement, MouseEvent>, skipMouseDown?: boolean) => {
-    if (!state.mouseDownBar && !skipMouseDown) return
-
-    const { offsetX } = e.nativeEvent
-    const scrollWidth = (e.target as HTMLDivElement).scrollWidth
-
-    const percentX = (offsetX / scrollWidth) * 100
-
-    calcBarColor(percentX)
-    state.barPercentX = percentX
-  })
-
-  // Calculate Base Color from Selected Color
   useTask$(() => {
     const [r, g, b] = selectedColor
       .substring(selectedColor.indexOf('(') + 1, selectedColor.indexOf(')'))
@@ -116,6 +92,79 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
     })
   )
 
+  useVisibleTask$(({ cleanup, track }) => {
+    track(() => state.showColorPicker)
+
+    const palateEl = palateRef.value
+    const colorBarEl = colorBarRef.value
+
+    if (!state.showColorPicker || !palateEl || !colorBarEl) return
+
+    const updatePalate = (e: MouseEvent) => {
+      const rect = palateEl.getBoundingClientRect()
+      const percentX = Math.max(0, Math.min(100, ((e.clientX - rect.left) / Palate.width) * 100))
+      const percentY = Math.max(0, Math.min(100, ((e.clientY - rect.top) / Palate.height) * 100))
+
+      calcPalateColor(percentX, percentY)
+      state.palatePercentX = percentX
+      state.palatePercentY = percentY
+    }
+
+    const updateColorBar = (e: MouseEvent) => {
+      const rect = colorBarEl.getBoundingClientRect()
+      const percentX = Math.max(0, Math.min(100, ((e.clientX - rect.left) / (rect.width || 1)) * 100))
+
+      calcBarColor(percentX)
+      state.barPercentX = percentX
+    }
+
+    const handlePalateMouseDown = (e: MouseEvent) => {
+      state.mouseDownPalate = true
+      updatePalate(e)
+    }
+
+    const handlePalateMouseMove = (e: MouseEvent) => {
+      if (!state.mouseDownPalate) return
+      updatePalate(e)
+    }
+
+    const handlePalateClick = (e: MouseEvent) => {
+      updatePalate(e)
+    }
+
+    const handleColorBarMouseDown = (e: MouseEvent) => {
+      state.mouseDownBar = true
+      updateColorBar(e)
+    }
+
+    const handleColorBarMouseMove = (e: MouseEvent) => {
+      if (!state.mouseDownBar) return
+      updateColorBar(e)
+    }
+
+    const handleColorBarClick = (e: MouseEvent) => {
+      updateColorBar(e)
+    }
+
+    palateEl.addEventListener('mousedown', handlePalateMouseDown)
+    palateEl.addEventListener('mousemove', handlePalateMouseMove)
+    palateEl.addEventListener('click', handlePalateClick)
+
+    colorBarEl.addEventListener('mousedown', handleColorBarMouseDown)
+    colorBarEl.addEventListener('mousemove', handleColorBarMouseMove)
+    colorBarEl.addEventListener('click', handleColorBarClick)
+
+    cleanup(() => {
+      palateEl.removeEventListener('mousedown', handlePalateMouseDown)
+      palateEl.removeEventListener('mousemove', handlePalateMouseMove)
+      palateEl.removeEventListener('click', handlePalateClick)
+
+      colorBarEl.removeEventListener('mousedown', handleColorBarMouseDown)
+      colorBarEl.removeEventListener('mousemove', handleColorBarMouseMove)
+      colorBarEl.removeEventListener('click', handleColorBarClick)
+    })
+  })
+
   return (
     <div class="flex flex-col gap-1">
       <button
@@ -127,14 +176,10 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
 
       {state.showColorPicker && (
         <div class="relative bg-slate-700 shadow-lg p-[2px] rounded-md">
-          {/* Color Palate */}
           <div
+            ref={palateRef}
             class="relative rounded overflow-hidden"
             style={{ height: Palate.height + 'px', width: Palate.width + 'px' }}
-            onMouseDown$={() => (state.mouseDownPalate = true)}
-            onMouseUp$={() => (state.mouseDownPalate = false)}
-            onMouseMove$={(e) => handlePalateMouseEvent(e, false)}
-            onClick$={(e) => handlePalateMouseEvent(e, true)}
           >
             <div class="absolute inset w-full h-full" style={{ background: `rgb(${state.baseColor})` }}>
               <div
@@ -146,7 +191,6 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
                   style="background: linear-gradient(to top, rgb(0, 0, 0), rgba(0, 0, 0, 0));"
                 ></div>
 
-                {/* Cursor */}
                 <div
                   class="absolute cursor-default pointer-events-none"
                   style={{ top: state.palatePercentY + '%', left: state.palatePercentX + '%' }}
@@ -162,14 +206,7 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
             </div>
           </div>
 
-          {/* Color Bar */}
-          <div
-            class="mt-[2px] w-full"
-            onMouseDown$={() => (state.mouseDownBar = true)}
-            onMouseUp$={() => (state.mouseDownBar = false)}
-            onMouseMove$={(e) => handleColorBarEvent(e, false)}
-            onClick$={(e) => handleColorBarEvent(e, true)}
-          >
+          <div ref={colorBarRef} class="mt-[2px] w-full">
             <div
               class="w-full h-6 rounded overflow-hidden relative"
               style={`background: linear-gradient(to right, ${Colors})`}

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -1,6 +1,5 @@
-import type { QRL } from '@builder.io/qwik'
-import { useTask$, useStore, useOnDocument } from '@builder.io/qwik'
-import { component$, $ } from '@builder.io/qwik'
+import { $, component$, useOnDocument, useStore, useTask$ } from '@builder.io/qwik'
+import type { QRL, QwikMouseEvent } from '@builder.io/qwik'
 
 const Colors = [
   'rgb(255,0,0)',
@@ -19,7 +18,7 @@ const Palate = {
 
 interface Props {
   selectedColor: string
-  setSelectedColor: QRL<(color: string) => string>
+  setSelectedColor: QRL<(color: string) => void>
 }
 
 export default component$<Props>(({ selectedColor, setSelectedColor }) => {
@@ -53,10 +52,10 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
   })
 
   // Palate mouse move handler
-  const handlePalateMouseEvent = $((e: any, skipMouseDown?: boolean) => {
+  const handlePalateMouseEvent = $((e: QwikMouseEvent<HTMLDivElement, MouseEvent>, skipMouseDown?: boolean) => {
     if (!state.mouseDownPalate && !skipMouseDown) return
 
-    const { offsetX, offsetY } = e
+    const { offsetX, offsetY } = e.nativeEvent
     const percentX = (offsetX / Palate.width) * 100
     const percentY = (offsetY / Palate.height) * 100
 
@@ -66,11 +65,11 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
   })
 
   // Bar mouse move handler
-  const handleColorBarEvent = $((e: any, skipMouseDown?: boolean) => {
+  const handleColorBarEvent = $((e: QwikMouseEvent<HTMLDivElement, MouseEvent>, skipMouseDown?: boolean) => {
     if (!state.mouseDownBar && !skipMouseDown) return
 
-    const { offsetX } = e
-    const { scrollWidth } = e.target
+    const { offsetX } = e.nativeEvent
+    const scrollWidth = (e.target as HTMLDivElement).scrollWidth
 
     const percentX = (offsetX / scrollWidth) * 100
 
@@ -94,18 +93,13 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
 
     const dropBoth = second[1] === third[1]
 
-    console.log(ratioOfSecond, ratioOfThird)
-
     rgbObj[second[0]] = dropBoth ? 0 : ratioOfThird > 0 ? (ratioOfSecond + ratioOfThird) / 2 : ratioOfSecond
     rgbObj[first[0]] = 255
     rgbObj[third[0]] = 0
 
-    console.log(rgbObj)
-
     state.baseColor = Object.values(rgbObj)
 
     const segments = { r: 0, g: 66.66, b: 33.33 }
-    console.log(segments[first[0]] + (second[1] / 255) * (100 / 3))
     state.barPercentX = segments[first[0]] + (second[1] / 255) * (100 / 3)
   })
 
@@ -128,6 +122,7 @@ export default component$<Props>(({ selectedColor, setSelectedColor }) => {
         style={{ background: selectedColor }}
         onClick$={() => (state.showColorPicker = !state.showColorPicker)}
         class="h-8 w-8 rounded"
+        title="Pick a color"
       />
 
       {state.showColorPicker && (

--- a/src/components/Controls/index.tsx
+++ b/src/components/Controls/index.tsx
@@ -1,0 +1,198 @@
+import { $, component$ } from '@builder.io/qwik'
+import type { QRL, QwikChangeEvent } from '@builder.io/qwik'
+
+import type { DrawShapeInput, ShapeType, State } from '~/routes'
+
+import ColorPicker from '../ColorPicker'
+import { Backspace } from '../icons/backspace'
+import { Circle } from '../icons/circle'
+import { Command } from '../icons/command'
+import { ImageFile } from '../icons/imageFile'
+import { Keyboard } from '../icons/keyboard'
+import { Redo } from '../icons/redo'
+import { Rectangle } from '../icons/retangle'
+import { Shift } from '../icons/shift'
+import { Undo } from '../icons/undo'
+
+const keyboardCommands = [
+  { key: '⇧ Click', command: 'Move' },
+  { key: 'F Click', command: 'Bring to Front' },
+  { key: '⌘ Scroll', command: 'Zoom' },
+  { key: 'Space Drag', command: 'Pan' },
+  { key: '⌘ Z', command: 'Undo' },
+  { key: '⇧ ⌘ Z', command: 'Redo' },
+  { key: '⌫', command: 'Delete' },
+  { key: 'c', command: 'Circle' },
+  { key: 'r', command: 'Rectangle' },
+  { key: 'i', command: 'Image' },
+] as const
+
+interface Props {
+  state: State
+  onUndo: QRL<() => void>
+  onRedo: QRL<() => void>
+  onClear: QRL<() => void>
+  onResetZoom: QRL<() => void>
+  onSelectShapeType: QRL<(shapeType: ShapeType) => void>
+  setSelectedColor: QRL<(color: string) => void>
+  drawShape: QRL<(props: DrawShapeInput) => Promise<void>>
+  screenToCanvas: QRL<(screenX: number, screenY: number) => Promise<{ canvasX: number; canvasY: number }>>
+}
+
+export default component$(
+  ({
+    state,
+    onUndo,
+    onRedo,
+    onClear,
+    onResetZoom,
+    onSelectShapeType,
+    setSelectedColor,
+    drawShape,
+    screenToCanvas,
+  }: Props) => {
+    const handleFileInput = $((e: QwikChangeEvent<HTMLInputElement>) => {
+      if (!e.target.files) return
+
+      const file = e.target.files[0]
+      const reader = new FileReader()
+
+      const handleErr = () => {
+        state.commandText = 'Error loading file'
+        setTimeout(() => (state.commandText = ''), 2000)
+      }
+
+      reader.onloadend = () => {
+        if (!reader.result) return handleErr()
+
+        const src = reader.result.toString()
+        const img = new Image()
+
+        img.onload = async () => {
+          const { canvasX, canvasY } = await screenToCanvas(innerWidth / 2, innerHeight / 2)
+          const width = img.width / state.scale / 2
+          const height = img.height / state.scale / 2
+
+          drawShape({
+            fillColor: 'transparent',
+            leftX: canvasX - width,
+            rightX: width + canvasX,
+            topY: canvasY - height,
+            bottomY: height + canvasY,
+            type: 'image',
+            src,
+          })
+        }
+
+        img.src = src
+      }
+
+      file ? reader.readAsDataURL(file) : handleErr()
+    })
+
+    return (
+      <>
+        <div class="absolute top-4 left-4 z-10">
+          <ColorPicker selectedColor={state.selectedColor} setSelectedColor={setSelectedColor} />
+        </div>
+
+        <div class="flex gap-1 text-lg text-white absolute bottom-4 left-4 z-10">
+          <button
+            onClick$={onUndo}
+            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
+          >
+            <Undo />
+          </button>
+
+          <button
+            onClick$={onRedo}
+            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
+          >
+            <Redo />
+          </button>
+
+          <button
+            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
+            onClick$={onClear}
+          >
+            Clear
+          </button>
+
+          <button
+            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
+            onClick$={onResetZoom}
+          >
+            {(state.scale * 100).toFixed(0)}%
+          </button>
+
+          {[
+            { icon: <Rectangle />, shape: 'rectangle' as ShapeType, shortcut: 'r' },
+            { icon: <Circle />, shape: 'circle' as ShapeType, shortcut: 'c' },
+          ].map(({ icon, shape, shortcut }) => (
+            <button
+              key={shape}
+              class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 transition duration-100 ${
+                state.currShapeType === shape ? '!bg-slate-700' : ''
+              }`}
+              onClick$={() => onSelectShapeType(shape)}
+            >
+              {icon}
+              <span class="absolute bottom-[-2px] right-[4px] text-[8px] hidden group-hover:block">{shortcut}</span>
+            </button>
+          ))}
+
+          <div
+            class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 grid place-items-center ${
+              state.currShapeType === 'image' ? 'bg-stone-800' : ''
+            }`}
+          >
+            <input
+              type="file"
+              onChange$={handleFileInput}
+              class="appearance-none absolute max-w-full w-full max-h-full h-full left-0 top-0 cursor-pointer opacity-0"
+            />
+
+            <ImageFile />
+            <span class="absolute bottom-[-2px] right-[4px] text-[8px] hidden group-hover:block">i</span>
+          </div>
+        </div>
+
+        <div class="absolute top-4 right-4 z-10">
+          <div class="relative text-white">
+            <button
+              class="px-2 h-8 text-xs border border-slate-700 bg-stone-900 rounded grid place-items-center"
+              onClick$={() => (state.showKeyShortcuts = !state.showKeyShortcuts)}
+            >
+              {state.commandText ? state.commandText : <Keyboard />}
+            </button>
+
+            {state.showKeyShortcuts && (
+              <div class="absolute right-0 top-[calc(100%+8px)] px-4 w-max text-xs border border-slate-700 rounded">
+                {keyboardCommands.map((shortcut) => (
+                  <span key={`${shortcut.command}-${shortcut.key}`} class="flex justify-between my-3 w-48">
+                    <span>{shortcut.command}</span>
+                    <span class="flex align-center">
+                      {shortcut.key.split(' ').map((key) => (
+                        <kbd
+                          key={`${shortcut.command}-${key}`}
+                          class="ml-1 text-[10px] text-xs leading-[110%] py-[4px] px-[3px] min-w-[20px] inline-grid place-items-center text-center rounded bg-stone-700"
+                        >
+                          {(() => {
+                            if (key === '⇧') return <Shift />
+                            if (key === '⌘') return <Command />
+                            if (key === '⌫') return <Backspace />
+                            return key
+                          })()}
+                        </kbd>
+                      ))}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </>
+    )
+  }
+)

--- a/src/components/Controls/index.tsx
+++ b/src/components/Controls/index.tsx
@@ -14,6 +14,12 @@ import { Rectangle } from '../icons/retangle'
 import { Shift } from '../icons/shift'
 import { Undo } from '../icons/undo'
 
+const chromeButtonClass =
+  'border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100'
+const iconButtonClass = `h-8 w-8 grid place-items-center ${chromeButtonClass}`
+const textButtonClass = `h-8 px-4 text-xs ${chromeButtonClass}`
+const shapeButtonClass = `h-8 px-4 text-xs ${chromeButtonClass} relative group`
+
 const keyboardCommands = [
   { key: '⇧ Click', command: 'Move' },
   { key: 'F Click', command: 'Bring to Front' },
@@ -25,6 +31,11 @@ const keyboardCommands = [
   { key: 'c', command: 'Circle' },
   { key: 'r', command: 'Rectangle' },
   { key: 'i', command: 'Image' },
+] as const
+
+const shapeButtons = [
+  { icon: <Rectangle />, shape: 'rectangle' as ShapeType, shortcut: 'r' },
+  { icon: <Circle />, shape: 'circle' as ShapeType, shortcut: 'c' },
 ] as const
 
 interface Props {
@@ -90,6 +101,13 @@ export default component$(
       file ? reader.readAsDataURL(file) : handleErr()
     })
 
+    const renderShortcutKey = (key: string) => {
+      if (key === '⇧') return <Shift />
+      if (key === '⌘') return <Command />
+      if (key === '⌫') return <Backspace />
+      return key
+    }
+
     return (
       <>
         <div class="absolute top-4 left-4 z-10">
@@ -97,41 +115,26 @@ export default component$(
         </div>
 
         <div class="flex gap-1 text-lg text-white absolute bottom-4 left-4 z-10">
-          <button
-            onClick$={onUndo}
-            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-          >
+          <button onClick$={onUndo} class={iconButtonClass}>
             <Undo />
           </button>
 
-          <button
-            onClick$={onRedo}
-            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-          >
+          <button onClick$={onRedo} class={iconButtonClass}>
             <Redo />
           </button>
 
-          <button
-            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-            onClick$={onClear}
-          >
+          <button class={textButtonClass} onClick$={onClear}>
             Clear
           </button>
 
-          <button
-            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-            onClick$={onResetZoom}
-          >
+          <button class={textButtonClass} onClick$={onResetZoom}>
             {(state.scale * 100).toFixed(0)}%
           </button>
 
-          {[
-            { icon: <Rectangle />, shape: 'rectangle' as ShapeType, shortcut: 'r' },
-            { icon: <Circle />, shape: 'circle' as ShapeType, shortcut: 'c' },
-          ].map(({ icon, shape, shortcut }) => (
+          {shapeButtons.map(({ icon, shape, shortcut }) => (
             <button
               key={shape}
-              class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 transition duration-100 ${
+              class={`${shapeButtonClass} ${
                 state.currShapeType === shape ? '!bg-slate-700' : ''
               }`}
               onClick$={() => onSelectShapeType(shape)}
@@ -142,7 +145,7 @@ export default component$(
           ))}
 
           <div
-            class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 grid place-items-center ${
+            class={`${shapeButtonClass} grid place-items-center ${
               state.currShapeType === 'image' ? 'bg-stone-800' : ''
             }`}
           >
@@ -177,12 +180,7 @@ export default component$(
                           key={`${shortcut.command}-${key}`}
                           class="ml-1 text-[10px] text-xs leading-[110%] py-[4px] px-[3px] min-w-[20px] inline-grid place-items-center text-center rounded bg-stone-700"
                         >
-                          {(() => {
-                            if (key === '⇧') return <Shift />
-                            if (key === '⌘') return <Command />
-                            if (key === '⌫') return <Backspace />
-                            return key
-                          })()}
+                          {renderShortcutKey(key)}
                         </kbd>
                       ))}
                     </span>

--- a/src/routes/index.css
+++ b/src/routes/index.css
@@ -16,14 +16,21 @@
 
 .selected-shape__resize-handle {
   color: rgba(255, 255, 255, 0.95);
-  cursor: pointer;
+  cursor: none;
 }
 
 .selected-shape__resize-handle-icon {
   width: 130%;
   height: 130%;
   filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
+  opacity: 0;
   pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.selected-shape__resize-handle:hover .selected-shape__resize-handle-icon,
+.selected-shape__resize-handle:active .selected-shape__resize-handle-icon {
+  opacity: 1;
 }
 
 /* Selected Shape Input Range */

--- a/src/routes/index.css
+++ b/src/routes/index.css
@@ -14,6 +14,18 @@
   rotate: var(--rotate);
 }
 
+.selected-shape__resize-handle {
+  color: rgba(255, 255, 255, 0.95);
+  cursor: pointer;
+}
+
+.selected-shape__resize-handle-icon {
+  width: 130%;
+  height: 130%;
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
+  pointer-events: none;
+}
+
 /* Selected Shape Input Range */
 
 .selected-shape__range {

--- a/src/routes/index.css
+++ b/src/routes/index.css
@@ -16,21 +16,14 @@
 
 .selected-shape__resize-handle {
   color: rgba(255, 255, 255, 0.95);
-  cursor: none;
+  cursor: pointer;
 }
 
 .selected-shape__resize-handle-icon {
   width: 130%;
   height: 130%;
   filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
-  opacity: 0;
   pointer-events: none;
-  transition: opacity 120ms ease;
-}
-
-.selected-shape__resize-handle:hover .selected-shape__resize-handle-icon,
-.selected-shape__resize-handle:active .selected-shape__resize-handle-icon {
-  opacity: 1;
 }
 
 /* Selected Shape Input Range */

--- a/src/routes/index.css
+++ b/src/routes/index.css
@@ -14,18 +14,6 @@
   rotate: var(--rotate);
 }
 
-.selected-shape__resize-handle {
-  color: rgba(255, 255, 255, 0.95);
-  cursor: pointer;
-}
-
-.selected-shape__resize-handle-icon {
-  width: 130%;
-  height: 130%;
-  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
-  pointer-events: none;
-}
-
 /* Selected Shape Input Range */
 
 .selected-shape__range {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -728,10 +728,10 @@ export default component$(() => {
 
                         {/* Resize Dots */}
                         {[
-                          { top: dotPos, left: dotPos, cursor: 'nw-resize' },
-                          { top: dotPos, right: dotPos, cursor: 'ne-resize' },
-                          { bottom: dotPos, left: dotPos, cursor: 'sw-resize' },
-                          { bottom: dotPos, right: dotPos, cursor: 'se-resize' },
+                          { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
+                          { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
+                          { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
+                          { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
                         ].map((dotLocation, i) => (
                           <span
                             onMouseDown$={(e) => handleShapeResizeMouseDown(e, i)}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -61,6 +61,67 @@ export interface State {
   showKeyShortcuts: boolean
 }
 
+interface Point {
+  x: number
+  y: number
+}
+
+const MIN_SHAPE_SIZE = 1
+
+const parseShapeRotation = (rotate: string) => {
+  if (rotate.endsWith('rad')) return parseFloat(rotate)
+  if (rotate.endsWith('deg')) return (parseFloat(rotate) * Math.PI) / 180
+  return 0
+}
+
+const rotatePoint = ({ x, y }: Point, radians: number): Point => ({
+  x: x * Math.cos(radians) - y * Math.sin(radians),
+  y: x * Math.sin(radians) + y * Math.cos(radians),
+})
+
+const getShapeCenter = (shape: Shape): Point => ({
+  x: shape.leftX + Math.abs(shape.rightX - shape.leftX) / 2,
+  y: shape.topY + Math.abs(shape.bottomY - shape.topY) / 2,
+})
+
+const getShapeDimensions = (shape: Shape) => ({
+  width: Math.abs(shape.rightX - shape.leftX),
+  height: Math.abs(shape.bottomY - shape.topY),
+})
+
+const getCornerSigns = (corner: number) => {
+  switch (corner) {
+    case 0:
+      return { x: -1, y: -1 }
+    case 1:
+      return { x: 1, y: -1 }
+    case 2:
+      return { x: -1, y: 1 }
+    default:
+      return { x: 1, y: 1 }
+  }
+}
+
+const getCornerIndexFromSigns = (x: number, y: number) => {
+  if (x < 0 && y < 0) return 0
+  if (x >= 0 && y < 0) return 1
+  if (x < 0 && y >= 0) return 2
+  return 3
+}
+
+const getShapeCornerPoint = (shape: Shape, corner: number): Point => {
+  const { width, height } = getShapeDimensions(shape)
+  const center = getShapeCenter(shape)
+  const radians = parseShapeRotation(shape.rotate)
+  const signs = getCornerSigns(corner)
+  const cornerOffset = rotatePoint({ x: (width / 2) * signs.x, y: (height / 2) * signs.y }, radians)
+
+  return {
+    x: center.x + cornerOffset.x,
+    y: center.y + cornerOffset.y,
+  }
+}
+
 export default component$(() => {
   useStylesScoped$(styles)
 
@@ -151,38 +212,38 @@ export default component$(() => {
     shape.bottomY += yDiff
   })
 
-  const moveShapeCorner = $(async (xDiff: number, yDiff: number, shape: Shape, corner: number) => {
+  const moveShapeCorner = $((pointerX: number, pointerY: number, shape: Shape, corner: number) => {
     if (!state.resizeMouseDownCoords) return
 
-    let { leftX, topY, rightX, bottomY } = shape
+    const radians = parseShapeRotation(shape.rotate)
+    const fixedCorner = getShapeCornerPoint(shape, 3 - corner)
+    const localVector = rotatePoint({ x: pointerX - fixedCorner.x, y: pointerY - fixedCorner.y }, -radians)
+    const previousSigns = getCornerSigns(corner)
 
-    if (corner === 0) {
-      leftX += xDiff
-      topY += yDiff
-      if (leftX > rightX) state.resizeMouseDownCoords.corner = 1
-      else if (topY > bottomY) state.resizeMouseDownCoords.corner = 2
-    } else if (corner === 1) {
-      rightX += xDiff
-      topY += yDiff
-      if (leftX > rightX) state.resizeMouseDownCoords.corner = 0
-      else if (topY > bottomY) state.resizeMouseDownCoords.corner = 3
-    } else if (corner === 2) {
-      leftX += xDiff
-      bottomY += yDiff
-      if (leftX > rightX) state.resizeMouseDownCoords.corner = 3
-      else if (topY > bottomY) state.resizeMouseDownCoords.corner = 0
-    } else if (corner === 3) {
-      rightX += xDiff
-      bottomY += yDiff
-      if (leftX > rightX) state.resizeMouseDownCoords.corner = 2
-      else if (topY > bottomY) state.resizeMouseDownCoords.corner = 1
+    const normalizedVector = {
+      x:
+        Math.abs(localVector.x) < MIN_SHAPE_SIZE
+          ? previousSigns.x * MIN_SHAPE_SIZE
+          : localVector.x,
+      y:
+        Math.abs(localVector.y) < MIN_SHAPE_SIZE
+          ? previousSigns.y * MIN_SHAPE_SIZE
+          : localVector.y,
     }
 
-    const correctedCoords = await correctRectangleDirection({ leftX, topY, rightX, bottomY })
-    shape.leftX = correctedCoords.leftX
-    shape.topY = correctedCoords.topY
-    shape.rightX = correctedCoords.rightX
-    shape.bottomY = correctedCoords.bottomY
+    const centerOffset = rotatePoint({ x: normalizedVector.x / 2, y: normalizedVector.y / 2 }, radians)
+    const center = {
+      x: fixedCorner.x + centerOffset.x,
+      y: fixedCorner.y + centerOffset.y,
+    }
+    const width = Math.abs(normalizedVector.x)
+    const height = Math.abs(normalizedVector.y)
+
+    shape.leftX = center.x - width / 2
+    shape.topY = center.y - height / 2
+    shape.rightX = center.x + width / 2
+    shape.bottomY = center.y + height / 2
+    state.resizeMouseDownCoords.corner = getCornerIndexFromSigns(normalizedVector.x, normalizedVector.y)
   })
 
   const drawShape = $(async (props: DrawShapeInput) => {
@@ -281,9 +342,9 @@ export default component$(() => {
     if (state.resizeMouseDownCoords) {
       if (!state.selectedShape) return
 
-      const { clientX: startX, clientY: startY, corner } = state.resizeMouseDownCoords
-      const { xDiff, yDiff } = await getScreenCoordDiff(startX, startY)
-      moveShapeCorner(xDiff, yDiff, state.selectedShape, corner)
+      const { corner } = state.resizeMouseDownCoords
+      const { canvasX, canvasY } = await screenToCanvas(clientX, clientY)
+      moveShapeCorner(canvasX, canvasY, state.selectedShape, corner)
       state.resizeMouseDownCoords.clientX = clientX
       state.resizeMouseDownCoords.clientY = clientY
     }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,37 +1,25 @@
-import { $, Resource, component$, useResource$, useOnWindow, useStore, useStylesScoped$ } from '@builder.io/qwik'
-import type { QwikChangeEvent, QwikMouseEvent } from '@builder.io/qwik'
+import { $, Resource, component$, useOnWindow, useResource$, useStore, useStylesScoped$ } from '@builder.io/qwik'
+import type { QwikMouseEvent } from '@builder.io/qwik'
 import { type DocumentHead } from '@builder.io/qwik-city'
 import cloneDeep from 'lodash.clonedeep'
 
+import Controls from '~/components/Controls'
+
 import styles from './index.css?inline'
-import ColorPicker from '~/components/ColorPicker'
 
-import { Redo } from '~/components/icons/redo'
-import { Undo } from '~/components/icons/undo'
-import { Keyboard } from '~/components/icons/keyboard'
-import { Shift } from '~/components/icons/shift'
-import { Command } from '~/components/icons/command'
-import { Backspace } from '~/components/icons/backspace'
-import { Rectangle } from '~/components/icons/retangle'
-import { Circle } from '~/components/icons/circle'
-import { ImageFile } from '~/components/icons/imageFile'
-// import { Triangle } from '~/components/icons/triangle'
+export type ShapeType = 'image' | 'rectangle' | 'circle' | 'triangle'
 
-const KeyboardCommands = [
-  { key: '⇧ Click', command: 'Move' },
-  { key: 'F Click', command: 'Bring to Front' },
-  { key: '⌘ Scroll', command: 'Zoom' },
-  { key: 'Space Drag', command: 'Pan' },
-  { key: '⌘ Z', command: 'Undo' },
-  { key: '⇧ ⌘ Z', command: 'Redo' },
-  { key: '⌫', command: 'Delete' },
-  { key: 'c', command: 'Circle' },
-  { key: 'r', command: 'Rectangle' },
-  // { key: 't', command: 'Triangle' },
-  { key: 'i', command: 'Image' },
-]
+export interface DrawShapeInput {
+  fillColor: string
+  leftX: number
+  topY: number
+  rightX: number
+  bottomY: number
+  src?: string
+  type?: ShapeType
+}
 
-interface Shape {
+export interface Shape {
   fillColor: string
   leftX: number
   topY: number
@@ -39,14 +27,13 @@ interface Shape {
   bottomY: number
   borderRadius: string
   rotate: string
-  type: 'image' | 'rectangle' | 'circle' | 'triangle'
+  type: ShapeType
   src?: string
   id: string
 }
 
 export interface State {
   canvasMouseMoveCoords: { clientX: number; clientY: number } | null
-
   canvasMouseDownCoords: { clientX: number; clientY: number } | null
   shapeMouseDownCoords: { clientX: number; clientY: number } | null
   resizeMouseDownCoords: { clientX: number; clientY: number; corner: number } | null
@@ -56,7 +43,7 @@ export interface State {
   selectedShape?: Shape
   history: { [key: number]: { shapes: Shape[] } }
   savesCount: number
-  currShapeType: Shape['type']
+  currShapeType: ShapeType
 
   selectedColor: string
 
@@ -80,7 +67,6 @@ export default component$(() => {
   const state = useStore<State>(
     {
       canvasMouseMoveCoords: null,
-
       canvasMouseDownCoords: null,
       shapeMouseDownCoords: null,
       resizeMouseDownCoords: null,
@@ -111,7 +97,17 @@ export default component$(() => {
   )
 
   const saveState = $(() => {
-    state.history[++state.savesCount] = cloneDeep({ shapes: state.shapes })
+    const nextHistory: State['history'] = {}
+
+    for (let i = 0; i <= state.savesCount; i += 1) {
+      if (state.history[i]) nextHistory[i] = state.history[i]
+    }
+
+    const nextIndex = state.savesCount + 1
+    nextHistory[nextIndex] = cloneDeep({ shapes: state.shapes })
+
+    state.history = nextHistory
+    state.savesCount = nextIndex
   })
 
   const undoState = $(() => {
@@ -119,31 +115,33 @@ export default component$(() => {
 
     const newState = state.history[--state.savesCount]
     if (!newState) return
-    state.shapes = newState.shapes
+
+    state.shapes = cloneDeep(newState.shapes)
+    state.selectedShape = undefined
   })
 
   const redoState = $(() => {
-    if (state.savesCount + 1 === Object.keys(state.history).length) return
+    const nextState = state.history[state.savesCount + 1]
+    if (!nextState) return
 
-    const newState = state.history[++state.savesCount]
-    if (!newState) return
-    state.shapes = newState.shapes
+    state.savesCount += 1
+    state.shapes = cloneDeep(nextState.shapes)
+    state.selectedShape = undefined
   })
 
   const clearShapes = $(() => {
     state.shapes = []
+    state.selectedShape = undefined
     saveState()
   })
 
   const correctRectangleDirection = $(
-    ({ leftX, topY, rightX, bottomY }: { leftX: number; topY: number; rightX: number; bottomY: number }) => {
-      return {
-        leftX: leftX > rightX ? rightX : leftX,
-        topY: topY > bottomY ? bottomY : topY,
-        rightX: leftX > rightX ? leftX : rightX,
-        bottomY: topY > bottomY ? topY : bottomY,
-      }
-    }
+    ({ leftX, topY, rightX, bottomY }: { leftX: number; topY: number; rightX: number; bottomY: number }) => ({
+      leftX: leftX > rightX ? rightX : leftX,
+      topY: topY > bottomY ? bottomY : topY,
+      rightX: leftX > rightX ? leftX : rightX,
+      bottomY: topY > bottomY ? topY : bottomY,
+    })
   )
 
   const moveShape = $((shape: Shape, xDiff: number, yDiff: number) => {
@@ -155,31 +153,25 @@ export default component$(() => {
 
   const moveShapeCorner = $(async (xDiff: number, yDiff: number, shape: Shape, corner: number) => {
     if (!state.resizeMouseDownCoords) return
+
     let { leftX, topY, rightX, bottomY } = shape
 
-    // Top Left
     if (corner === 0) {
       leftX += xDiff
       topY += yDiff
       if (leftX > rightX) state.resizeMouseDownCoords.corner = 1
       else if (topY > bottomY) state.resizeMouseDownCoords.corner = 2
-    }
-    // Top Right
-    else if (corner === 1) {
+    } else if (corner === 1) {
       rightX += xDiff
       topY += yDiff
       if (leftX > rightX) state.resizeMouseDownCoords.corner = 0
       else if (topY > bottomY) state.resizeMouseDownCoords.corner = 3
-    }
-    // Bottom Left
-    else if (corner === 2) {
+    } else if (corner === 2) {
       leftX += xDiff
       bottomY += yDiff
       if (leftX > rightX) state.resizeMouseDownCoords.corner = 3
       else if (topY > bottomY) state.resizeMouseDownCoords.corner = 0
-    }
-    // Bottom Right
-    else if (corner === 3) {
+    } else if (corner === 3) {
       rightX += xDiff
       bottomY += yDiff
       if (leftX > rightX) state.resizeMouseDownCoords.corner = 2
@@ -193,36 +185,30 @@ export default component$(() => {
     shape.bottomY = correctedCoords.bottomY
   })
 
-  const drawShape = $(
-    async (props: {
-      fillColor: string
-      leftX: number
-      topY: number
-      rightX: number
-      bottomY: number
-      src?: string
-      type?: Shape['type']
-    }) => {
-      const { fillColor, leftX, topY, rightX, bottomY, src, type } = props
-      const correctedCoords = await correctRectangleDirection({ leftX, topY, rightX, bottomY })
+  const drawShape = $(async (props: DrawShapeInput) => {
+    const { fillColor, leftX, topY, rightX, bottomY, src, type } = props
+    const correctedCoords = await correctRectangleDirection({ leftX, topY, rightX, bottomY })
 
-      const shape: Shape = {
-        ...correctedCoords,
-        fillColor,
-        rotate: '0deg',
-        borderRadius: state.currShapeType === 'circle' ? '50%' : '0%',
-        id: 'id' + new Date().getTime(),
-        type: type || state.currShapeType,
-      }
-      if (src && shape.type === 'image') shape.src = src
-      state.shapes.push(shape)
-      saveState()
-      state.selectedShape = shape
+    const shape: Shape = {
+      ...correctedCoords,
+      fillColor,
+      rotate: '0deg',
+      borderRadius: (type || state.currShapeType) === 'circle' ? '50%' : '0%',
+      id: `id${Date.now()}`,
+      type: type || state.currShapeType,
     }
-  )
+
+    if (src && shape.type === 'image') shape.src = src
+
+    state.shapes.push(shape)
+    state.selectedShape = shape
+    saveState()
+  })
 
   const deleteShape = $((shape: Shape) => {
     state.shapes = state.shapes.filter((s) => s.id !== shape.id)
+    state.selectedShape = undefined
+    saveState()
   })
 
   const bringToFront = $((shape: Shape) => {
@@ -230,37 +216,30 @@ export default component$(() => {
     if (shapeIndex > -1) {
       const [removedShape] = state.shapes.splice(shapeIndex, 1)
       state.shapes.push(removedShape)
-    }
-    saveState()
-  })
-
-  const screenToCanvas = $((screenX: number, screenY: number) => {
-    return {
-      canvasX: (screenX - state.zoomPos.x - (innerWidth / 2) * (1 - state.scale)) / state.scale,
-      canvasY: (screenY - state.zoomPos.y - (innerHeight / 2) * (1 - state.scale)) / state.scale,
+      saveState()
     }
   })
 
-  const canvasToScreen = $((canvasX: number, canvasY: number) => {
-    return {
-      screenX: (canvasX - state.zoomPos.x) / state.scale,
-      screenY: (canvasY - state.zoomPos.y) / state.scale,
-    }
-  })
+  const screenToCanvas = $((screenX: number, screenY: number) => ({
+    canvasX: (screenX - state.zoomPos.x - (innerWidth / 2) * (1 - state.scale)) / state.scale,
+    canvasY: (screenY - state.zoomPos.y - (innerHeight / 2) * (1 - state.scale)) / state.scale,
+  }))
 
-  // Rotate Mouse Handler
+  const canvasToScreen = $((canvasX: number, canvasY: number) => ({
+    screenX: canvasX * state.scale + state.zoomPos.x + (innerWidth / 2) * (1 - state.scale),
+    screenY: canvasY * state.scale + state.zoomPos.y + (innerHeight / 2) * (1 - state.scale),
+  }))
+
   const handleShapeRotateMouseDown = $((e: QwikMouseEvent<HTMLSpanElement, MouseEvent>) => {
     e.stopPropagation()
     state.rotateMouseDownCoords = { clientX: e.clientX, clientY: e.clientY }
   })
 
-  // Resize Mouse Handler
   const handleShapeResizeMouseDown = $((e: QwikMouseEvent<HTMLSpanElement, MouseEvent>, corner: number) => {
     e.stopPropagation()
     state.resizeMouseDownCoords = { clientX: e.clientX, clientY: e.clientY, corner }
   })
 
-  // Shape Mouse Handler
   const handleShapeMouseDown = $((e: QwikMouseEvent<HTMLSpanElement, MouseEvent>, shape: Shape) => {
     if (state.keyDown === 'Shift') {
       state.shapeMouseDownCoords = { clientX: e.clientX, clientY: e.clientY }
@@ -268,24 +247,19 @@ export default component$(() => {
     }
   })
 
-  const handleShapeClick = $((shape: Shape) => {
+  const handleShapeClick = $((e: QwikMouseEvent<HTMLSpanElement>, shape: Shape) => {
+    e.stopPropagation()
+
     if (state.commandText === 'Delete') deleteShape(shape)
     else if (state.commandText === 'Bring to Front') bringToFront(shape)
-    else if (!state.canvasMouseDownCoords) state.selectedShape = shape
+    else state.selectedShape = shape
   })
 
-  // Canvas Mouse Handlers
-  const handleCanvasMouseDown = $(({ clientX, clientY }: QwikMouseEvent<HTMLSpanElement, MouseEvent>) => {
+  const handleCanvasMouseDown = $(({ clientX, clientY }: QwikMouseEvent<HTMLDivElement, MouseEvent>) => {
     state.canvasMouseDownCoords = { clientX, clientY }
   })
 
-  /**
-   *
-   * Canvas Mouse Move Listener
-   *
-   */
-  const handleCanvasMouseMove = $(async ({ clientX, clientY }: QwikMouseEvent<HTMLSpanElement, MouseEvent>) => {
-    // Pan Canvas
+  const handleCanvasEventMove = $(async (clientX: number, clientY: number) => {
     if (state.commandText === 'Pan' && state.canvasMouseDownCoords) {
       state.zoomPos.x += clientX - (state.canvasMouseMoveCoords?.clientX || clientX)
       state.zoomPos.y += clientY - (state.canvasMouseMoveCoords?.clientY || clientY)
@@ -297,7 +271,6 @@ export default component$(() => {
       return { xDiff: endClientX - startClientX, yDiff: endClientY - startClientY }
     }
 
-    // Move Shape
     if (state.keyDown === 'Shift' && state.shapeMouseDownCoords && state.selectedShape) {
       const { clientX: startX, clientY: startY } = state.shapeMouseDownCoords
       const { xDiff, yDiff } = await getScreenCoordDiff(startX, startY)
@@ -305,9 +278,9 @@ export default component$(() => {
       state.shapeMouseDownCoords = { clientX, clientY }
     }
 
-    // Resize Shape
     if (state.resizeMouseDownCoords) {
       if (!state.selectedShape) return
+
       const { clientX: startX, clientY: startY, corner } = state.resizeMouseDownCoords
       const { xDiff, yDiff } = await getScreenCoordDiff(startX, startY)
       moveShapeCorner(xDiff, yDiff, state.selectedShape, corner)
@@ -315,7 +288,6 @@ export default component$(() => {
       state.resizeMouseDownCoords.clientY = clientY
     }
 
-    // Rotate Shape
     if (state.rotateMouseDownCoords) {
       if (!state.selectedShape) return
 
@@ -330,8 +302,7 @@ export default component$(() => {
       const radians = Math.atan2(startX - centerX, startY - centerY)
       const cornerRadians = Math.atan2(rightX - centerX, topY - centerY)
 
-      state.selectedShape.rotate = -(radians - cornerRadians) + 'rad'
-
+      state.selectedShape.rotate = `${-(radians - cornerRadians)}rad`
       state.rotateMouseDownCoords.clientX = clientX
       state.rotateMouseDownCoords.clientY = clientY
     }
@@ -339,25 +310,26 @@ export default component$(() => {
     state.canvasMouseMoveCoords = { clientX, clientY }
   })
 
-  /**
-   *
-   * Canvas Mouse Up Event Listener
-   *
-   */
-  const handleCanvasMouseUp = $(async (e: QwikMouseEvent<HTMLSpanElement, MouseEvent>) => {
-    const { clientX: endClientX, clientY: endClientY } = e
+  const handleCanvasMouseMove = $(async ({ clientX, clientY }: QwikMouseEvent<HTMLDivElement, MouseEvent>) => {
+    handleCanvasEventMove(clientX, clientY)
+  })
 
-    // Draw Shape
+  const handleCanvasRelease = $(async (releaseX: number, releaseY: number) => {
+    const transformedShape =
+      !!state.canvasMouseMoveCoords &&
+      (!!state.shapeMouseDownCoords || !!state.resizeMouseDownCoords || !!state.rotateMouseDownCoords)
+
     if (!state.keyDown && state.canvasMouseDownCoords) {
       const { clientX, clientY } = state.canvasMouseDownCoords
-      const mouseMoved = endClientX - clientX !== 0 && endClientY - clientY !== 0
+      const mouseMoved = releaseX - clientX !== 0 && releaseY - clientY !== 0
 
       const { canvasX: leftX, canvasY: topY } = await screenToCanvas(clientX, clientY)
-      const { canvasX: rightX, canvasY: bottomY } = await screenToCanvas(endClientX, endClientY)
+      const { canvasX: rightX, canvasY: bottomY } = await screenToCanvas(releaseX, releaseY)
 
-      mouseMoved
-        ? await drawShape({ fillColor: state.selectedColor, leftX, topY, rightX, bottomY })
-        : (state.selectedShape = undefined)
+      if (mouseMoved) await drawShape({ fillColor: state.selectedColor, leftX, topY, rightX, bottomY })
+      else state.selectedShape = undefined
+    } else if (transformedShape) {
+      saveState()
     }
 
     state.canvasMouseMoveCoords = null
@@ -367,12 +339,11 @@ export default component$(() => {
     state.rotateMouseDownCoords = null
   })
 
-  /**
-   *
-   * Preview Style Resource
-   *
-   */
-  const previewStyle = useResource$<any>(async ({ track }) => {
+  const handleCanvasMouseUp = $(async ({ clientX, clientY }: QwikMouseEvent<HTMLDivElement, MouseEvent>) => {
+    handleCanvasRelease(clientX, clientY)
+  })
+
+  const previewStyle = useResource$<Record<string, string> | undefined>(async ({ track }) => {
     const canvasMouseDownCoords = track(() => state.canvasMouseDownCoords)
     const canvasMouseMoveCoords = track(() => state.canvasMouseMoveCoords)
 
@@ -389,78 +360,24 @@ export default component$(() => {
     const coords = await correctRectangleDirection({ leftX, topY, rightX, bottomY })
 
     return {
-      '--left': coords.leftX + 'px',
-      '--top': coords.topY + 'px',
-      '--height': Math.abs(coords.bottomY - coords.topY) + 'px',
-      '--width': Math.abs(coords.rightX - coords.leftX) + 'px',
+      '--left': `${coords.leftX}px`,
+      '--top': `${coords.topY}px`,
+      '--height': `${Math.abs(coords.bottomY - coords.topY)}px`,
+      '--width': `${Math.abs(coords.rightX - coords.leftX)}px`,
       '--background': state.selectedColor,
       '--border-radius': state.currShapeType === 'circle' ? '50%' : '0px',
     }
   })
 
-  /**
-   *
-   *
-   *
-   */
-  const handleFileInput = $((e: QwikChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files) return
-
-    const file = e.target.files[0]
-    const reader = new FileReader()
-
-    const handleErr = () => {
-      state.commandText = 'Error loading file'
-      setTimeout(() => (state.commandText = ''), 2000)
-    }
-
-    reader.onloadend = () => {
-      if (!reader?.result) return handleErr()
-
-      const src = reader.result.toString()
-      const img = new Image()
-
-      img.onload = async () => {
-        const { canvasX, canvasY } = await screenToCanvas(innerWidth / 2, innerHeight / 2)
-        const width = img.width / state.scale / 2
-        const height = img.height / state.scale / 2
-
-        drawShape({
-          fillColor: 'transparent',
-          leftX: canvasX - width,
-          rightX: width + canvasX,
-          topY: canvasY - height,
-          bottomY: height + canvasY,
-          type: 'image',
-          src,
-        })
-      }
-      img.src = src
-    }
-    file ? reader.readAsDataURL(file) : handleErr()
-  })
-
-  /**
-   *
-   *
-   *
-   */
   useOnWindow(
     'keydown',
     $((e: Event) => {
-      // @ts-ignore
-      const { key, metaKey, shiftKey, altKey } = e as {
-        key: string
-        metaKey: boolean
-        shiftKey: boolean
-        altKey: boolean
-      }
+      const { key, metaKey, shiftKey, altKey } = e as KeyboardEvent
+
       state.keyDown = key
       state.metaKey = metaKey
       state.shiftKey = shiftKey
       state.altKey = altKey
-
-      console.log(key)
 
       switch (key) {
         case 'F':
@@ -468,8 +385,7 @@ export default component$(() => {
           state.commandText = 'Bring to Front'
           break
         case 'Backspace':
-          state.shapes = state.shapes.filter((shape) => state.selectedShape?.id !== shape.id)
-          saveState()
+          if (state.selectedShape) deleteShape(state.selectedShape)
           state.commandText = 'Delete'
           break
         case 'Shift':
@@ -512,11 +428,6 @@ export default component$(() => {
     })
   )
 
-  /**
-   *
-   *
-   *
-   */
   useOnWindow(
     'keyup',
     $(() => {
@@ -528,30 +439,24 @@ export default component$(() => {
     })
   )
 
-  /**
-   *
-   * Zoom on mouse wheel event
-   *
-   */
   useOnWindow(
     'wheel',
-    $(async (e: any) => {
+    $(async (event: Event) => {
+      const e = event as WheelEvent & { wheelDelta?: number; originalEvent?: { detail?: number } }
+
       e.preventDefault()
       if (!e.metaKey) return
 
-      // Cursor pos relative to center of window
       const zoomPointX = e.clientX - window.innerWidth / 2
       const zoomPointY = e.clientY - window.innerHeight / 2
 
-      // Calc the point where cursor is on screen
       const { screenX, screenY } = await canvasToScreen(zoomPointX, zoomPointY)
 
-      // Determine if zooming in or out
-      const direction = e.wheelDelta || e.originalEvent.detail // Chrome || Firefox
-      const delta = Math.max(-1, Math.min(1, direction)) // Cap the delta to [-1,1] for cross browser consistency
+      const direction = e.wheelDelta || e.originalEvent?.detail || 0
+      const delta = Math.max(-1, Math.min(1, direction))
 
-      const scale = state.scale + delta * state.zoomFactor * state.scale // Calculate new scale using previous scale
-      state.scale = Math.max(state.minScale, Math.min(state.maxScale, scale)) // Clamp scale between min and max
+      const scale = state.scale + delta * state.zoomFactor * state.scale
+      state.scale = Math.max(state.minScale, Math.min(state.maxScale, scale))
 
       state.zoomPos.x = -screenX * state.scale + zoomPointX
       state.zoomPos.y = -screenY * state.scale + zoomPointY
@@ -560,266 +465,168 @@ export default component$(() => {
 
   return (
     <>
-      {/* Controls */}
-      <>
-        {/* Color Picker */}
-        <div class="absolute top-4 left-4 z-10">
-          <ColorPicker
-            selectedColor={state.selectedColor}
-            setSelectedColor={$((color: string) => (state.selectedColor = color))}
-          />
-        </div>
+      <Controls
+        state={state}
+        onUndo={undoState}
+        onRedo={redoState}
+        onClear={clearShapes}
+        onResetZoom={$(() => {
+          state.scale = 1
+        })}
+        onSelectShapeType={$((shapeType: ShapeType) => {
+          state.currShapeType = shapeType
+        })}
+        setSelectedColor={$((color: string) => {
+          state.selectedColor = color
+        })}
+        drawShape={drawShape}
+        screenToCanvas={screenToCanvas}
+      />
 
-        <div class="flex gap-1 text-lg text-white absolute bottom-4 left-4 z-10">
-          <button
-            onClick$={undoState}
-            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-          >
-            <Undo />
-          </button>
-
-          <button
-            onClick$={redoState}
-            class="h-8 w-8 grid place-items-center border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-          >
-            <Redo />
-          </button>
-
-          <button
-            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-            onClick$={clearShapes}
-          >
-            Clear
-          </button>
-
-          {/* Zoom */}
-          <button
-            class="h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded hover:bg-stone-800 transition duration-100"
-            onClick$={() => (state.scale = 1)}
-          >
-            {(state.scale * 100).toFixed(0)}%
-          </button>
-
-          {/* Shapes */}
-          {[
-            { icon: <Rectangle />, shape: 'rectangle', shortcut: 'r' },
-            { icon: <Circle />, shape: 'circle', shortcut: 'c' },
-            // { icon: <Triangle />, shape: 'triangle', shortcut: 't' },
-          ].map(({ icon, shape, shortcut }) => (
-            <button
-              class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 transition duration-100
-            ${state.currShapeType === shape && '!bg-slate-700'}`}
-              onClick$={() => (state.currShapeType = shape as State['currShapeType'])}
-            >
-              {icon}
-              <span class="absolute bottom-[-2px] right-[4px] text-[8px] hidden group-hover:block">{shortcut}</span>
-            </button>
-          ))}
-
-          {/* Image Input */}
-          <div
-            class={`h-8 px-4 text-xs border border-slate-700 bg-stone-900 rounded relative group hover:bg-stone-800 grid place-items-center
-            ${state.currShapeType === 'image' && 'bg-stone-800'}`}
-          >
-            <input
-              type="file"
-              onChange$={handleFileInput}
-              class="appearance-none absolute max-w-full w-full max-h-full h-full left-0 top-0 cursor-pointer opacity-0"
-            />
-
-            <ImageFile />
-            <span class="absolute bottom-[-2px] right-[4px] text-[8px] hidden group-hover:block">i</span>
-          </div>
-        </div>
-
-        {/* Keyboard Shortcuts */}
-        <div class="absolute top-4 right-4 z-10">
-          <div class="relative text-white">
-            <button
-              class="px-2 h-8 text-xs border border-slate-700 bg-stone-900 rounded grid place-items-center"
-              onClick$={() => (state.showKeyShortcuts = !state.showKeyShortcuts)}
-            >
-              {state.commandText ? state.commandText : <Keyboard />}
-            </button>
-
-            {state.showKeyShortcuts && (
-              <div class="absolute right-0 top-[calc(100%+8px)] px-4 w-max text-xs border border-slate-700 rounded">
-                {KeyboardCommands.map((shortcut) => (
-                  <span class="flex justify-between my-3 w-48">
-                    <span>{shortcut.command}</span>{' '}
-                    <span class="flex align-center">
-                      {shortcut.key.split(' ').map((key) => (
-                        <kbd class="ml-1 text-[10px] text-xs leading-[110%] py-[4px] px-[3px] min-w-[20px] inline-grid place-items-center text-center rounded bg-stone-700">
-                          {(() => {
-                            if (key === '⇧') return <Shift />
-                            if (key === '⌘') return <Command />
-                            if (key === '⌫') return <Backspace />
-                            return key
-                          })()}
-                        </kbd>
-                      ))}
-                    </span>
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      </>
-
-      {/* Canvas */}
       <div
-        class="h-screen w-full max-w-screen bg-stone-900 overflow-hidden absolute top-0 left-0 z-0 touch-pan-y touch-pan-x select-none"
+        class="h-screen w-full max-w-screen bg-stone-900 overflow-hidden absolute inset-0 z-0 touch-pan-y touch-pan-x select-none"
         onMouseDown$={handleCanvasMouseDown}
         onMouseMove$={handleCanvasMouseMove}
         onMouseUp$={handleCanvasMouseUp}
+        onClick$={() => (state.selectedShape = undefined)}
         preventdefault:mousedown
         preventdefault:mouseup
       >
         <div
           class="canvas h-full w-full"
           style={{
-            transform: 'translate(' + state.zoomPos.x + 'px,' + state.zoomPos.y + 'px) scale(' + state.scale + ')',
+            transform: `translate(${state.zoomPos.x}px, ${state.zoomPos.y}px) scale(${state.scale})`,
           }}
         >
-          {/* Drawn Shapes */}
           {state.shapes.map((shape) => {
             const dotSize = 12
-            const dotPos = -(dotSize / 2 / state.scale) + 'px'
+            const dotPos = `${-(dotSize / 2 / state.scale)}px`
             const isSelected = state.selectedShape?.id === shape.id
             const height = Math.abs(shape.bottomY - shape.topY || 1)
             const width = Math.abs(shape.rightX - shape.leftX || 1)
 
             return (
-              <>
-                <span
-                  onClick$={() => handleShapeClick(shape)}
-                  onMouseDown$={(e) => handleShapeMouseDown(e, shape)}
-                  preventdefault:mousedown
-                  class={`shape absolute 
-                   ${state.keyDown === 'Shift' && 'cursor-grab active:cursor-grabbing'}
-                   ${state.commandText == 'Bring to Front' && 'cursor-crosshair'}`}
-                  style={{
-                    '--left': shape.leftX + 'px',
-                    '--top': shape.topY + 'px',
-                    '--height': height + 'px',
-                    '--width': width + 'px',
-                    '--border-radius': shape.borderRadius,
-                    '--rotate': shape.rotate,
-                    '--background': shape.fillColor,
-                  }}
-                >
-                  <div class="h-full w-full relative">
-                    {shape.type === 'image' && (
-                      <img
-                        src={shape.src}
-                        alt="Shape Image"
-                        class="h-full w-full absolute object-contain rounded-[var(--border-radius)]"
-                      />
-                    )}
+              <span
+                key={shape.id}
+                onClick$={(e) => handleShapeClick(e, shape)}
+                onMouseDown$={(e) => handleShapeMouseDown(e, shape)}
+                preventdefault:mousedown
+                class={`shape absolute ${state.keyDown === 'Shift' ? 'cursor-grab active:cursor-grabbing' : ''} ${
+                  state.commandText === 'Bring to Front' ? 'cursor-crosshair' : ''
+                }`}
+                style={{
+                  '--left': `${shape.leftX}px`,
+                  '--top': `${shape.topY}px`,
+                  '--height': `${height}px`,
+                  '--width': `${width}px`,
+                  '--border-radius': shape.borderRadius,
+                  '--rotate': shape.rotate,
+                  '--background': shape.fillColor,
+                }}
+              >
+                <div class="h-full w-full relative">
+                  {shape.type === 'image' && (
+                    <img
+                      src={shape.src}
+                      alt="Shape image"
+                      class="h-full w-full absolute object-contain rounded-[var(--border-radius)]"
+                    />
+                  )}
 
-                    {isSelected && (
-                      <>
-                        {/* Selected Border */}
+                  {isSelected && (
+                    <>
+                      <span class="h-full w-full absolute" style={{ border: `${1 / state.scale}px solid white` }} />
+
+                      {[
+                        { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
+                        { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
+                        { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
+                        { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
+                      ].map((dotLocation, i) => (
                         <span
-                          class="h-full w-full absolute"
-                          style={{ border: isSelected ? 1 / state.scale + 'px solid white' : 'none' }}
+                          key={i}
+                          onMouseDown$={(e) => handleShapeResizeMouseDown(e, i)}
+                          class="absolute"
+                          style={{
+                            height: `${dotSize / state.scale}px`,
+                            width: `${dotSize / state.scale}px`,
+                            ...dotLocation,
+                          }}
                         />
+                      ))}
 
-                        {/* Resize Dots */}
-                        {[
-                          { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
-                          { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
-                          { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
-                          { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
-                        ].map((dotLocation, i) => (
-                          <span
-                            onMouseDown$={(e) => handleShapeResizeMouseDown(e, i)}
-                            class="absolute"
-                            style={{
-                              height: dotSize / state.scale + 'px',
-                              width: dotSize / state.scale + 'px',
-                              ...dotLocation,
+                      <div
+                        class="absolute top-0 bottom-0 m-auto w-2 h-fit transition-opacity"
+                        style={{
+                          '--slider-width': '8px',
+                          '--slider-height': `clamp(50px, ${height / 2}px, ${(130 + height / 4) * state.scale}px)`,
+                          left: `calc(100% + calc(.75rem * ${1 / state.scale}))`,
+                          scale: `${1 / state.scale}`,
+                          opacity: state.rotateMouseDownCoords ? '0' : '1',
+                        }}
+                      >
+                        <div class="flex justify-center items-center rotate-90 -mb-4">
+                          <input
+                            style={{ minWidth: 'var(--slider-height)' }}
+                            class="selected-shape__range cursor-ns-resize outline-none rounded-full bg-gray-700 appearance-none"
+                            onMouseDown$={(e) => e.stopPropagation()}
+                            type="range"
+                            min="0"
+                            max="50"
+                            step="0.5"
+                            value={parseInt(shape.borderRadius)}
+                            onInput$={(e) => {
+                              shape.borderRadius = `${parseFloat((e.target as HTMLInputElement).value || '0')}%`
                             }}
                           />
-                        ))}
-
-                        {/* Border Radius Control */}
-                        <div
-                          class="absolute top-0 bottom-0 m-auto w-2 h-fit transition-opacity"
-                          style={{
-                            '--slider-width': `8px`,
-                            '--slider-height': `clamp(50px, ${height / 2}px, ${(130 + height / 4) * state.scale}px)`,
-                            left: `calc(100% + calc(.75rem * ${1 / state.scale}))`,
-                            scale: 1 / state.scale,
-                            opacity: state.rotateMouseDownCoords ? '0' : '1',
-                          }}
-                        >
-                          <div class="flex justify-center items-center rotate-90 -mb-4">
-                            <input
-                              style={{ minWidth: `var(--slider-height)` }}
-                              class="selected-shape__range cursor-ns-resize outline-none rounded-full bg-gray-700 appearance-none"
-                              onMouseDown$={(e) => e.stopPropagation()}
-                              type="range"
-                              min="0"
-                              max="50"
-                              step="0.5"
-                              value={parseInt(shape.borderRadius)}
-                              // @ts-ignore
-                              onInput$={(e) => (shape.borderRadius = parseInt(e.target?.value || 0) + '%')}
-                            />
-                            <output class="text-gray-400 w-4 text-[.65rem] flex items-center justify-between -rotate-90">
-                              {shape.borderRadius}
-                            </output>
-                          </div>
+                          <output class="text-gray-400 w-4 text-[.65rem] flex items-center justify-between -rotate-90">
+                            {shape.borderRadius}
+                          </output>
                         </div>
+                      </div>
 
-                        {/* Rotate Control */}
-                        <div
-                          class="slider absolute left-full bottom-full text-gray-500 cursor-grab active:cursor-grabbing"
-                          onMouseDown$={(e) => handleShapeRotateMouseDown(e)}
-                        >
-                          <div class="relative">
-                            <svg
-                              style={{ opacity: state.rotateMouseDownCoords ? '0' : '1', rotate: '25deg' }}
-                              class="transition-opacity"
-                              stroke="currentColor"
-                              fill="currentColor"
-                              stroke-width="0"
-                              viewBox="0 0 256 256"
-                              height={20 / state.scale + 'px'}
-                              width={20 / state.scale + 'px'}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path d="M236,184a12,12,0,0,1-24,0A84,84,0,0,0,68.6,124.6L53.11,140H88a12,12,0,0,1,0,24H24a12,12,0,0,1-12-12V88a12,12,0,0,1,24,0v35.16l15.66-15.55A108,108,0,0,1,236,184Z"></path>
-                            </svg>
+                      <div
+                        class="slider absolute left-full bottom-full text-gray-500 cursor-grab active:cursor-grabbing"
+                        onMouseDown$={(e) => handleShapeRotateMouseDown(e)}
+                      >
+                        <div class="relative">
+                          <svg
+                            style={{ opacity: state.rotateMouseDownCoords ? '0' : '1', rotate: '25deg' }}
+                            class="transition-opacity"
+                            stroke="currentColor"
+                            fill="currentColor"
+                            viewBox="0 0 256 256"
+                            height={`${20 / state.scale}px`}
+                            width={`${20 / state.scale}px`}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path d="M236,184a12,12,0,0,1-24,0A84,84,0,0,0,68.6,124.6L53.11,140H88a12,12,0,0,1,0,24H24a12,12,0,0,1-12-12V88a12,12,0,0,1,24,0v35.16l15.66-15.55A108,108,0,0,1,236,184Z"></path>
+                          </svg>
 
-                            <span
-                              style={{
-                                opacity: state.rotateMouseDownCoords ? '1' : '0',
-                                rotate: `calc(-1 * ${shape.rotate})`,
-                              }}
-                              class="absolute left-full bottom-full text-gray-400 w-4 text-[.65rem] flex items-center justify-between cursor-pointer transition-opacity"
-                              onClick$={() => (shape.rotate = '0deg')}
-                            >
-                              {shape.rotate.includes('rad')
-                                ? (parseFloat(shape.rotate) * (180 / Math.PI)).toFixed(1) + 'º'
-                                : parseFloat(shape.rotate).toFixed(1) + 'º'}
-                            </span>
-                          </div>
+                          <span
+                            style={{
+                              opacity: state.rotateMouseDownCoords ? '1' : '0',
+                              rotate: `calc(-1 * ${shape.rotate})`,
+                            }}
+                            class="absolute left-full bottom-full text-gray-400 w-4 text-[.65rem] flex items-center justify-between cursor-pointer transition-opacity"
+                            onClick$={() => (shape.rotate = '0deg')}
+                          >
+                            {shape.rotate.includes('rad')
+                              ? `${(parseFloat(shape.rotate) * (180 / Math.PI)).toFixed(1)}º`
+                              : `${parseFloat(shape.rotate).toFixed(1)}º`}
+                          </span>
                         </div>
-                      </>
-                    )}
-                  </div>
-                </span>
-              </>
+                      </div>
+                    </>
+                  )}
+                </div>
+              </span>
             )
           })}
 
-          {/* Shape Preview */}
           <Resource
             value={previewStyle}
-            onResolved={(styles: CSSModuleClasses | undefined) => <span class="shape absolute" style={styles} />}
+            onResolved={(styles) => (styles ? <span class="shape absolute" style={styles} /> : <span />)}
           />
         </div>
       </div>
@@ -828,5 +635,5 @@ export default component$(() => {
 })
 
 export const head: DocumentHead = {
-  title: 'Qwik Ascii',
+  title: 'Qwikdraw',
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -122,6 +122,8 @@ const getShapeCornerPoint = (shape: Shape, corner: number): Point => {
   }
 }
 
+const getResizeHandleAngle = (corner: number) => (corner === 0 || corner === 3 ? 45 : -45)
+
 export default component$(() => {
   useStylesScoped$(styles)
 
@@ -599,21 +601,54 @@ export default component$(() => {
                       <span class="h-full w-full absolute" style={{ border: `${1 / state.scale}px solid white` }} />
 
                       {[
-                        { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
-                        { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
-                        { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
-                        { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
+                        { top: dotPos, left: dotPos },
+                        { top: dotPos, right: dotPos },
+                        { bottom: dotPos, left: dotPos },
+                        { bottom: dotPos, right: dotPos },
                       ].map((dotLocation, i) => (
                         <span
                           key={i}
                           onMouseDown$={(e) => handleShapeResizeMouseDown(e, i)}
-                          class="absolute"
+                          class="selected-shape__resize-handle absolute flex items-center justify-center"
                           style={{
                             height: `${dotSize / state.scale}px`,
                             width: `${dotSize / state.scale}px`,
+                            '--handle-icon-rotate': `${getResizeHandleAngle(i)}deg`,
                             ...dotLocation,
                           }}
-                        />
+                        >
+                          <svg
+                            class="selected-shape__resize-handle-icon overflow-visible"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <g transform="rotate(var(--handle-icon-rotate) 12 12)">
+                              <path
+                                d="M6.5 12h11"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-width="1.75"
+                              />
+                              <path
+                                d="M6.5 12l3-3M6.5 12l3 3"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="1.75"
+                              />
+                              <path
+                                d="M17.5 12l-3-3M17.5 12l-3 3"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="1.75"
+                              />
+                            </g>
+                          </svg>
+                        </span>
                       ))}
 
                       <div

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -344,15 +344,10 @@ export default component$(() => {
       state.zoomPos.y += clientY - (state.canvasMouseMoveCoords?.clientY || clientY)
     }
 
-    const getScreenCoordDiff = async (startX: number, startY: number) => {
-      const { screenX: startClientX, screenY: startClientY } = await canvasToScreen(startX, startY)
-      const { screenX: endClientX, screenY: endClientY } = await canvasToScreen(clientX, clientY)
-      return { xDiff: endClientX - startClientX, yDiff: endClientY - startClientY }
-    }
-
     if (state.keyDown === 'Shift' && state.shapeMouseDownCoords && state.selectedShape) {
       const { clientX: startX, clientY: startY } = state.shapeMouseDownCoords
-      const { xDiff, yDiff } = await getScreenCoordDiff(startX, startY)
+      const xDiff = (clientX - startX) / state.scale
+      const yDiff = (clientY - startY) / state.scale
       moveShape(state.selectedShape, xDiff, yDiff)
       state.shapeMouseDownCoords = { clientX, clientY }
     }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -122,6 +122,24 @@ const getShapeCornerPoint = (shape: Shape, corner: number): Point => {
   }
 }
 
+const getResizeCursor = (corner: number, rotate: string) => {
+  const baseAngle = corner === 0 || corner === 3 ? 45 : 135
+  const rotationDegrees = (parseShapeRotation(rotate) * 180) / Math.PI
+  const normalizedAngle = ((baseAngle + rotationDegrees) % 180 + 180) % 180
+  const snappedAngle = Math.round(normalizedAngle / 45) * 45
+
+  switch (snappedAngle % 180) {
+    case 0:
+      return 'ew-resize'
+    case 45:
+      return 'nwse-resize'
+    case 90:
+      return 'ns-resize'
+    default:
+      return 'nesw-resize'
+  }
+}
+
 export default component$(() => {
   useStylesScoped$(styles)
 
@@ -599,10 +617,10 @@ export default component$(() => {
                       <span class="h-full w-full absolute" style={{ border: `${1 / state.scale}px solid white` }} />
 
                       {[
-                        { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
-                        { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
-                        { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
-                        { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
+                        { top: dotPos, left: dotPos },
+                        { top: dotPos, right: dotPos },
+                        { bottom: dotPos, left: dotPos },
+                        { bottom: dotPos, right: dotPos },
                       ].map((dotLocation, i) => (
                         <span
                           key={i}
@@ -611,6 +629,7 @@ export default component$(() => {
                           style={{
                             height: `${dotSize / state.scale}px`,
                             width: `${dotSize / state.scale}px`,
+                            cursor: getResizeCursor(i, shape.rotate),
                             ...dotLocation,
                           }}
                         />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -122,8 +122,6 @@ const getShapeCornerPoint = (shape: Shape, corner: number): Point => {
   }
 }
 
-const getResizeHandleAngle = (corner: number) => (corner === 0 || corner === 3 ? 45 : -45)
-
 export default component$(() => {
   useStylesScoped$(styles)
 
@@ -601,54 +599,21 @@ export default component$(() => {
                       <span class="h-full w-full absolute" style={{ border: `${1 / state.scale}px solid white` }} />
 
                       {[
-                        { top: dotPos, left: dotPos },
-                        { top: dotPos, right: dotPos },
-                        { bottom: dotPos, left: dotPos },
-                        { bottom: dotPos, right: dotPos },
+                        { top: dotPos, left: dotPos, cursor: 'nwse-resize' },
+                        { top: dotPos, right: dotPos, cursor: 'nesw-resize' },
+                        { bottom: dotPos, left: dotPos, cursor: 'nesw-resize' },
+                        { bottom: dotPos, right: dotPos, cursor: 'nwse-resize' },
                       ].map((dotLocation, i) => (
                         <span
                           key={i}
                           onMouseDown$={(e) => handleShapeResizeMouseDown(e, i)}
-                          class="selected-shape__resize-handle absolute flex items-center justify-center"
+                          class="absolute"
                           style={{
                             height: `${dotSize / state.scale}px`,
                             width: `${dotSize / state.scale}px`,
-                            '--handle-icon-rotate': `${getResizeHandleAngle(i)}deg`,
                             ...dotLocation,
                           }}
-                        >
-                          <svg
-                            class="selected-shape__resize-handle-icon overflow-visible"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                          >
-                            <g transform="rotate(var(--handle-icon-rotate) 12 12)">
-                              <path
-                                d="M6.5 12h11"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-width="1.75"
-                              />
-                              <path
-                                d="M6.5 12l3-3M6.5 12l3 3"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.75"
-                              />
-                              <path
-                                d="M17.5 12l-3-3M17.5 12l-3 3"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.75"
-                              />
-                            </g>
-                          </svg>
-                        </span>
+                        />
                       ))}
 
                       <div

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -8,12 +8,6 @@ export default component$(() => {
           <Slot />
         </section>
       </main>
-      <footer class="absolute bottom-4 right-4 text-sm text-slate-500 group">
-        Made with <span class="group-hover:text-red-500">♡</span> by{' '}
-        <a href="https://www.christiancodes.co/" target="_blank">
-          Christian
-        </a>
-      </footer>
     </>
   )
 })

--- a/tests/color-picker.spec.ts
+++ b/tests/color-picker.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+test('color picker updates swatch from palette and hue strip', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173/')
+
+  const swatch = page.getByTitle('Pick a color')
+  await swatch.click()
+
+  const swatchColorBefore = await swatch.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+  const palette = page.locator('div[style="height: 200px; width: 200px;"]').first()
+  await palette.click({ position: { x: 60, y: 60 } })
+
+  await expect
+    .poll(async () => swatch.evaluate((el) => getComputedStyle(el).backgroundColor))
+    .not.toBe(swatchColorBefore)
+
+  const swatchColorAfterPalette = await swatch.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+  const hueStrip = page.locator('div[style*="linear-gradient(to right, rgb(255, 0, 0), rgb(255, 0, 255), rgb(0, 0, 255)"]').first()
+  const swatchColorBeforeHue = swatchColorAfterPalette
+  await hueStrip.click({ position: { x: 140, y: 12 } })
+
+  await expect
+    .poll(async () => swatch.evaluate((el) => getComputedStyle(el).backgroundColor))
+    .not.toBe(swatchColorBeforeHue)
+})

--- a/tests/rotated-resize.spec.ts
+++ b/tests/rotated-resize.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Locator } from '@playwright/test'
+
+const getCornerPoint = async (shape: Locator, corner: number) =>
+  shape.evaluate((el, cornerIndex) => {
+    const readNumber = (property: string) => parseFloat(el.style.getPropertyValue(property) || '0')
+    const rotateValue = el.style.getPropertyValue('--rotate') || '0deg'
+    const rotate = rotateValue.endsWith('rad')
+      ? parseFloat(rotateValue)
+      : (parseFloat(rotateValue) * Math.PI) / 180
+
+    const left = readNumber('--left')
+    const top = readNumber('--top')
+    const width = readNumber('--width')
+    const height = readNumber('--height')
+    const centerX = left + width / 2
+    const centerY = top + height / 2
+
+    const signs =
+      cornerIndex === 0
+        ? { x: -1, y: -1 }
+        : cornerIndex === 1
+          ? { x: 1, y: -1 }
+          : cornerIndex === 2
+            ? { x: -1, y: 1 }
+            : { x: 1, y: 1 }
+
+    const localX = (width / 2) * signs.x
+    const localY = (height / 2) * signs.y
+
+    return {
+      x: centerX + localX * Math.cos(rotate) - localY * Math.sin(rotate),
+      y: centerY + localX * Math.sin(rotate) + localY * Math.cos(rotate),
+    }
+  }, corner)
+
+test('resizing a rotated shape keeps the opposite corner fixed', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173/')
+
+  const canvas = page.locator('.canvas')
+  const canvasBox = await canvas.boundingBox()
+  if (!canvasBox) throw new Error('Canvas not rendered')
+
+  await page.mouse.move(canvasBox.x + 180, canvasBox.y + 180)
+  await page.mouse.down()
+  await page.mouse.move(canvasBox.x + 320, canvasBox.y + 280)
+  await page.mouse.up()
+
+  const shape = page.locator('.shape').first()
+  await expect(shape).toBeVisible()
+  await shape.click()
+
+  const rotateHandle = page.locator('.slider').first()
+  const rotateBox = await rotateHandle.boundingBox()
+  if (!rotateBox) throw new Error('Rotate handle not rendered')
+
+  await page.mouse.move(rotateBox.x + rotateBox.width / 2, rotateBox.y + rotateBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(rotateBox.x + rotateBox.width / 2 + 30, rotateBox.y + rotateBox.height / 2 + 20)
+  await page.mouse.move(rotateBox.x + rotateBox.width / 2 + 60, rotateBox.y + rotateBox.height / 2 + 40)
+  await page.mouse.up()
+
+  await expect
+    .poll(async () => shape.evaluate((el) => el.style.getPropertyValue('--rotate')))
+    .not.toBe('0deg')
+
+  const oppositeCornerBefore = await getCornerPoint(shape, 3)
+
+  const topLeftHandle = page.locator('.shape span.absolute').nth(1)
+  const handleBox = await topLeftHandle.boundingBox()
+  if (!handleBox) throw new Error('Resize handle not rendered')
+
+  await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(handleBox.x - 40, handleBox.y - 25)
+  await page.mouse.up()
+
+  const oppositeCornerAfter = await getCornerPoint(shape, 3)
+
+  expect(Math.abs(oppositeCornerAfter.x - oppositeCornerBefore.x)).toBeLessThan(1.5)
+  expect(Math.abs(oppositeCornerAfter.y - oppositeCornerBefore.y)).toBeLessThan(1.5)
+})


### PR DESCRIPTION
## Summary
- add minimum scale handling and resize arrow updates on the `selected-shapes` branch
- extract the editor toolbar into a dedicated `Controls` component
- clean up editor state handling so draw, move, resize, rotate, undo, and redo remain stable
- tighten `ColorPicker` event typing and remove the layout footer

## Testing
- npm run build.types
- npm run lint
- npm run build